### PR TITLE
Cleanup

### DIFF
--- a/mosek/PKGBUILD
+++ b/mosek/PKGBUILD
@@ -10,8 +10,7 @@
 #   examples of problems MOSEK can solve are linear programs, quadratic
 #   programs, conic problems, and mixed integer problems [...]''
 
-pkgbase=mosek
-pkgname=('mosek')
+pkgname='mosek'
 pkgdesc="A tool for solving mathematical optimization problems."
 pkgver=7.0.85
 pkgrel=1
@@ -22,34 +21,17 @@ license=('custom')
 # XXX: Matlab is a dependency (libmex, libmat, etc.)
 depends=('gcc-libs' 'java-environment' 'bash')
 
-# XXX: Binary package
-makedepends=()
-
-provides=("mosek=${pkgver}")
-replaces=('mosek')
 options=('!libtool' '!strip')
 
 if test "$CARCH" == "x86_64"; then
   _mosekarch=linux64x86
   sha512sums=('035bcb84f587abc00d69cd11cb3ac571244482d5430e87acb4febc9b59d5766ecbd52d9d8ff6e1c7de672e3f45025814fa45ae6496114d1878436675f39acda5')
-  sha384sums=('ff0f73c299ae2b13d3a780d86b4512c3ae40ff2c7c18a4df05e3af4489289d141117c688cc060da6493b03e184bc0d0c')
-  sha256sums=('3998486b59dcb46b0d654c234b38c863f3547ab8425fbf9da5b5cc504c617995')
-  sha1sums=('659e1e3e379a1db71d43c4c8601f42b176e76a8e')
-  md5sums=('2bc4158e49404a8ce010963df6050c4b')
 elif test "$CARCH" == "i686"; then
   _mosekarch=linux32x86
   sha512sums=('7fc23aa3b790e3579613e0db0c42cf17ba6795969cd3bfe11e773a470d00d71eeae742b3433e7f89eea618cd4f1754e2279fabd636ec8affe7f6741a0c212500')
-  sha384sums=('7dfe571864062e9530abbad465ee18e01604d777d856231477842bc719e1c8e9e31d38e89c55cc2ff843423a46ae8c32')
-  sha256sums=('974b73bba4028dd19492d9476745ee85ecd157d7e8334916c154ccc10c433df5')
-  sha1sums=('7ba83a32d80edc23ed696b3ec21272e4460fa7f4')
-  md5sums=('5eff1eca0655cf20e6cf240868a23288')
 fi
 
 source=("http://download.mosek.com/stable/7/mosektools${_mosekarch}.tar.bz2")
-
-build() {
-  cd "${srcdir}/"
-}
 
 check() {
   cd "${srcdir}/"
@@ -61,34 +43,34 @@ package() {
   cd "${srcdir}/"
  
   # Install binaries into /opt/mosek/7: 
-  install -dm755                  ${pkgdir}/opt/mosek/7
-  cp -r mosek/7/.                 ${pkgdir}/opt/mosek/7/.
+  install -dm755                  "${pkgdir}/opt/mosek/7"
+  cp -r mosek/7/.                 "${pkgdir}/opt/mosek/7/."
 
   # Symlink mosek:
-  install -dm755                  ${pkgdir}/usr/bin
+  install -dm755                  "${pkgdir}/usr/bin"
   ln -s /opt/mosek/7/tools/platform/${_mosekarch}/bin/mosek \
-                                  ${pkgdir}/usr/bin/mosek
+                                  "${pkgdir}/usr/bin/mosek"
 
   # Symlink header file:
-  install -dm755                  ${pkgdir}/usr/include
+  install -dm755                  "${pkgdir}/usr/include"
   ln -s /opt/mosek/7/tools/platform/${_mosekarch}/h/mosek.h \
-                                  ${pkgdir}/usr/include/mosek.h
+                                  "${pkgdir}/usr/include/mosek.h"
 
   # Symlink documentation, examples, and licenses:
-  install -dm755                  ${pkgdir}/usr/share/doc/mosek
+  install -dm755                  "${pkgdir}/usr/share/doc/mosek"
   ln -s /opt/mosek/7/tools/examples \
-                                  ${pkgdir}/usr/share/doc/mosek/examples
-  ln -s /opt/mosek/7/doc/html     ${pkgdir}/usr/share/doc/mosek/html
-  ln -s /opt/mosek/7/doc/pdf      ${pkgdir}/usr/share/doc/mosek/pdf
+                                  "${pkgdir}/usr/share/doc/mosek/examples"
+  ln -s /opt/mosek/7/doc/html     "${pkgdir}/usr/share/doc/mosek/html"
+  ln -s /opt/mosek/7/doc/pdf      "${pkgdir}/usr/share/doc/mosek/pdf"
 
-  install -dm755                  ${pkgdir}/usr/share/licenses/mosek
-  ln -s /opt/mosek/7/license.pdf  ${pkgdir}/usr/share/licenses/mosek/license.pdf
+  install -dm755                  "${pkgdir}/usr/share/licenses/mosek"
+  ln -s /opt/mosek/7/license.pdf  "${pkgdir}/usr/share/licenses/mosek/license.pdf"
 
   # Symlink MATLAB toolbox:
-  ln -s /opt/mosek/7/toolbox      ${pkgdir}/usr/share/doc/mosek/matlab
+  ln -s /opt/mosek/7/toolbox      "${pkgdir}/usr/share/doc/mosek/matlab"
 
   # Symlink Python modules:
   ln -s /opt/mosek/7/tools/platform/${_mosekarch}/python \
-                                  ${pkgdir}/usr/share/doc/mosek/python
+                                  "${pkgdir}/usr/share/doc/mosek/python"
 
 }


### PR DESCRIPTION
pkgbase is not used unless it's a split package
pkgname is a single variable, not an array unless it's a split package
Don't need empty makedepends array
Should not "provide" and "conflict" with itself.
Only need one checksum
Don't need empty build function
All uses of $pkgdir should be quoted.
