### PR TITLE
Some tweaks and corrections

### DIFF
--- a/bmon-git/PKGBUILD
+++ b/bmon-git/PKGBUILD
@@ -8,57 +8,40 @@
 # 
 
 pkgname="bmon-git"
-pkgver=v3.2.0.gd47fffc
+pkgver=3.2.0.gd47fffc
 pkgrel=1
 pkgdesc="Portable bandwidth monitor and rate estimator"
 arch=('i686' 'x86_64')
 url="http://people.suug.ch/~tgr/bmon/"
 license=('MIT')
-depends=('ncurses' 'confuse')
+depends=('confuse' 'ncurses')
 makedepends=()
+provides=("${pkgname%-*}")
+conflicts=("${pkgname%-*}")
 source=('git+https://github.com/tgraf/bmon.git')
 sha512sums=('SKIP')
-provides=('bmon')
-replaces=('bmon')
-conflicts=('bmon')
 
 pkgver() {
-  cd "${srcdir}/${pkgname//-git/}"
+  cd "${pkgname%-*}"
 
-  if [ -n "${BMON_VERSION}" ]; then
-    git checkout "${BMON_VERSION}"
-  fi
-
-  local ver="$(git describe --tags --long --always --dirty)"
-  printf "%s" "${ver//-/.}"
-}
-
-prepare() {
-  cd "${srcdir}/${pkgname//-git/}"
-
-  if [ -n "${BMON_VERSION}" ]; then
-    git checkout "${BMON_VERSION}"
-  fi
+  printf "%s" "$(git describe --long --tags | sed 's/v//; s/-/./g')"
 }
 
 build() {
-  cd "${srcdir}/${pkgname//-git/}"
+  cd "${pkgname%-*}"
 
   ./autogen.sh
-  ./configure --prefix=/usr --mandir=/usr/share/man --disable-asound
+  ./configure --prefix=/usr --sysconfdir=/etc --disable-asound
   make
 }
 
 package() {
-  cd "${srcdir}/${pkgname//-git/}"
+  cd "${pkgname%-*}"
 
   make DESTDIR="${pkgdir}" install
 
-  install -d                "${pkgdir}/usr/share/doc/${pkgname}"
-  install -m644 ChangeLog   "${pkgdir}/usr/share/doc/${pkgname}"
-  install -m644 LICENSE     "${pkgdir}/usr/share/doc/${pkgname}"
-
-  install -d                "${pkgdir}/usr/share/licenses/${pkgname}"
-  ln -s "/usr/share/doc/${pkgname}/LICENSE" \
-                            "${pkgdir}/usr/share/licenses/${pkgname}"
+  install -dm 755 "${pkgdir}/usr/share/doc/${pkgname%-*}"
+  install -m 644 ChangeLog LICENSE "${pkgdir}/usr/share/doc/${pkgname%-*}/"
+  install -dm 755 "${pkgdir}/usr/share/licenses/${pkgname}"
+  ln -s "/usr/share/doc/${pkgname-*}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/"
 }


### PR DESCRIPTION
- Prefer stripping the leading v on the version number
- List deps alphabetically (this is a personal preference)
- You don't need replaces with git packages
- Didn't change that, but sha512 is probably overkill, I prefer sha256
- Functions implicetely cd into $srcdir (some TUs still prefer explicitely cding into it, I don't)
- ${pkgname%-*} is shorter :P
- Your BMON_VERSION lines can be achieved with fragments in the source array (see VCS guidelines on the wiki)
- Man dir always default to that, however your sysconfdir was wrong
- docs and manpages should be in a folder without the -git suffix, only license folder needs to match the package name
