### PR TITLE
Only remove "v" from beginning of pkgver

### DIFF
--- a/aur/ceph-git/PKGBUILD
+++ b/aur/ceph-git/PKGBUILD
@@ -44,7 +44,7 @@ sha256sums=('SKIP'
 pkgver() {
   cd "${srcdir}/${pkgname%%-git}"
   #printf "%s" "$(git describe --long --tags | sed 's/v//; s/-/./g')"
-  git describe --long --tags | sed 's/v//; s/-/./g'
+  git describe --long --tags | sed 's/^v//; s/-/./g'
 }
 
 prepare() {


### PR DESCRIPTION
If you don't use the caret, it will remove any "v"s from the hash of the commit.
