### PR TITLE
Update lxc-docker-git to use upstream hack/make.sh

### DIFF
--- a/aur/lxc-docker-git/PKGBUILD
+++ b/aur/lxc-docker-git/PKGBUILD
@@ -55,9 +55,12 @@ build() {
   mkdir -p github.com/dotcloud
   mv docker github.com/dotcloud
 
-  # TODO FIXME: probably should switch to building using hack/makedist.sh...
-  go build -v -a github.com/dotcloud/docker/docker
-  go build -v -a github.com/dotcloud/docker/dockerinit
+  pushd github.com/dotcloud/docker
+  ./hack/make.sh dynbinary
+  popd
+  dockerver=$(cat github.com/dotcloud/docker/VERSION)
+  cp github.com/dotcloud/docker/bundles/docker-$dockerver/dynbinary/docker-$dockerver docker
+  cp github.com/dotcloud/docker/bundles/docker-$dockerver/dynbinary/dockerinit-$dockerver dockerinit
 
 #manpage build fails due to sphinx bug 
 #so we build html help for now
@@ -77,7 +80,8 @@ package() {
 
   # install docker binaries
   install -D -m 755 "$srcdir/docker" "$pkgdir/usr/bin/docker"
-  install -D -m 755 "$srcdir/dockerinit" "$pkgdir/usr/bin/dockerinit"
+  mkdir -p "$pkgdir/usr/libexec/docker"
+  install -D -m 755 "$srcdir/dockerinit" "$pkgdir/usr/libexec/docker/dockerinit"
 
   install -D -m 644 "github.com/dotcloud/docker/contrib/completion/bash/docker" "$pkgdir/usr/share/bash-completion/completions/docker"
   


### PR DESCRIPTION
As one of the maintainers of the upstream "hack" directory (and the included build scripts), we really request that packagers use them, and I work hard to make sure they work well for packagers. :)

I wish I had an easy way to test this for you, but my Arch-fu is not strong.  Hopefully it's close enough that you can help me adapt it the rest of the way. :)

Also, I'm willing to answer any questions or resolve any concerns you might have about this!  I'm pretty much always on IRC in the #docker channel on freenode. :+1:  They call me "packagers relations" because I'm always whining about how we can make life better for our good packagers. :cake:

(I tried to match the style of the surrounding code as best I could, and I'm sorry if I messed up anywhere, and will be happy to rebase this PR to fix it!)
