### PR TITLE
add duplicity-bzr makedepends for bazaar

### DIFF
--- a/aur/duplicity-bzr/PKGBUILD
+++ b/aur/duplicity-bzr/PKGBUILD
@@ -24,6 +24,7 @@ optdepends=('lftp: FTPS backend'
             'python2-httplib2: Ubuntu One backend'
             'python2-oauthlib: Ubuntu One backend'
             'rsync: rsync backend')
+makedepends=('bzr')
 source=(bzr+lp:duplicity)
 sha512sums=('SKIP')
 #_bzrtrunk='https://code.launchpad.net/~duplicity-team/duplicity/trunk'


### PR DESCRIPTION
duplicity-bzr fails to compile if you don't have bazaar installed (well duh..). Anyway adding bazaar to makedepends fixes the problem
