### PR TITLE
add: provides('duplicity')

### DIFF
--- a/aur/duplicity-bzr/PKGBUILD
+++ b/aur/duplicity-bzr/PKGBUILD
@@ -30,6 +30,7 @@ sha512sums=('SKIP')
 #_bzrtrunk='https://code.launchpad.net/~duplicity-team/duplicity/trunk'
 #_bzrmod=${pkgname}
 conflicts=("${pkgname//-bzr/}")
+provides=('duplicity')
 
 pkgver() {
   cd "${srcdir}/${pkgname//-bzr/}"


### PR DESCRIPTION
The package provides duplicity. Packages relying on duplicity, such as
deja-dup and duply work fine with the bzr version, but could not be
installed otherwise.
