### PR TITLE
Add another patch to Ceph 0.87 to fix deadlock on exit

### DIFF
--- a/aur/ceph/PKGBUILD
+++ b/aur/ceph/PKGBUILD
@@ -31,6 +31,7 @@ options=('!libtool' 'emptydirs')
 source=("http://ceph.com/download/$pkgname-$pkgver.tar.bz2"
         "boost-fix.patch"
         "rwunlock-sigill-fix.patch"
+        "ceph-tool-hang-on-exit.patch"
         "ceph-osd@.service"
         "ceph-mon@.service"
         "ceph-mds@.service"
@@ -38,6 +39,7 @@ source=("http://ceph.com/download/$pkgname-$pkgver.tar.bz2"
 sha256sums=('6ca61e32c6b04f92d68f735408a981f95da699a65845908e5617b25defe90b32'
             'd7c36b7661c8a0745158bfaf54081eb9566f00cc3101ddeec3ea3817cd3594d4'
             'd326c13d56bc7657365e7acff53f1910240c62b88bba79447af8e83c78e7f737'
+            'ff6cb7f21471244bd37bf87c909874b4893cfc4bc9465adf6427f50904112a45'
             '29483c0f6718e8830cf52c0d31e391fb52dc1b460bcb65cf9c72dfab83e5b5ce'
             'a50811ce62fd6cdcc17d8f1e4d9700c1889ab4bfc5e9a22155bd725a27715e3c'
             'b8239a04cc42e3e4ced2e141df6804e61e875131a5c95d6bcbfc3b44f388d44b'
@@ -54,6 +56,9 @@ prepare() {
   # that a backport is needed, so there may be a 0.87.1 at some point
   # that fixes this upstream.
   patch -p1 -i $srcdir/rwunlock-sigill-fix.patch
+
+  # Patch is from PR 3053 (https://github.com/ceph/ceph/pull/3053/commits).
+  patch -p1 -i $srcdir/ceph-tool-hang-on-exit.patch
 
   # fix python scripts to use python2
   find . -type f -exec sed -i 's,^#!/usr/bin/env python$,#!/usr/bin/env python2,g' {} \;

--- a/aur/ceph/ceph-tool-hang-on-exit.patch
+++ b/aur/ceph/ceph-tool-hang-on-exit.patch
@@ -1,0 +1,14 @@
+--- a/src/ceph.in
++++ b/src/ceph.in
+@@ -841,4 +841,10 @@ def main():
+     return 0
+ 
+ if __name__ == '__main__':
+-    sys.exit(main())
++    result = main()
++
++    # sys.exit doesn't necessarily trigger threads to garbage collect
++    # clean up the class and shutdown the thread
++    del cluster_handle
++
++    sys.exit(result)


### PR DESCRIPTION
Ceph 0.87 as of my last PR has a bug where the `ceph` tool hangs on exit, because it's relying on the Python interpreter doing some GC that it's not required to do. This results in librados.so blocking the shutdown of the python interpreter.

The fix for that isn't submitted to ceph master yet, but the patch in the PR definitely fixes the issue, so I grabbed it ahead of time.
