### PR TITLE
Add POCO_ODBC_LIB="/usr/lib" to make and make install

### DIFF
--- a/aur/poco/PKGBUILD
+++ b/aur/poco/PKGBUILD
@@ -27,13 +27,13 @@ build()
 {
   cd "${srcdir}/poco-${_pkgver}-all"
   ./configure --prefix=/usr --no-samples --no-tests
-  make ODBCLIBDIR="/usr/lib"
+  make POCO_ODBC_LIB="/usr/lib" ODBCLIBDIR="/usr/lib"
 }
 
 package()
 {
   cd "${srcdir}/poco-${_pkgver}-all"
-  make ODBCLIBDIR="/usr/lib" DESTDIR="${pkgdir}" install
+  make POCO_ODBC_LIB="/usr/lib" ODBCLIBDIR="/usr/lib" DESTDIR="${pkgdir}" install
   install -Dm644 'LICENSE' "${pkgdir}/usr/share/licenses/poco/LICENSE"
 
   chrpath -d "${pkgdir}/usr/bin/cpspc"


### PR DESCRIPTION
Fix poco build error by adding `POCO_ODBC_LIB="/usr/lib"` to both the `make` and `make install` commands.