### PR TITLE
updated dpkg to 1.17.25 from debian

### DIFF
--- a/aur/dpkg/PKGBUILD
+++ b/aur/dpkg/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: Jochen Schalanda <jochen+aur (at) schalanda.name>
+# Contributor: C. Dominik Bódi <dominik.bodi@gmx.de>
 # Contributor: Pierre Carrier <pierre@spotify.com>
 # Contributor: Thomas Dziedzic <gostrc (at) gmail>
 # Contributor: Chris Giles <Chris.G.27 (at) Gmail.com>
@@ -12,7 +13,7 @@
 #       Otherwise, open a GitHub issue.  Thank you! -Ido
 #
 pkgname=dpkg
-pkgver=1.16.15
+pkgver=1.17.25
 pkgrel=1
 pkgdesc="The Debian Package Manager.  Don't use it instead of Arch's 'pacman'."
 arch=('i686' 'x86_64')
@@ -27,8 +28,8 @@ source=(
 	http://ftp.debian.org/debian/pool/main/d/${pkgname}/${pkgname}_${pkgver}.tar.xz
 	dpkg-gzip-rsyncable.patch
 )
-md5sums=('0e7d105a57839cdab2b0bf5e3612442f'
-         '5ab63758999e9bb10f84bce79a0307b2')
+md5sums=('e48fcfdb2162e77d72c2a83432d537ca'
+         '71fd0c244ca1fc7132c708022ca50ef0')
 
 build() {
 	cd "${pkgname}-${pkgver}"

--- a/aur/dpkg/dpkg-gzip-rsyncable.patch
+++ b/aur/dpkg/dpkg-gzip-rsyncable.patch
@@ -1,11 +1,11 @@
 --- ./scripts/Dpkg/Compression.pm.orig	2012-04-27 04:49:02.000000000 +0200
 +++ ./scripts/Dpkg/Compression.pm	2012-05-27 22:23:18.530628795 +0200
-@@ -52,7 +52,7 @@
+@@ -53,7 +53,7 @@
  my $COMP = {
-     "gzip" => {
- 	"file_ext" => "gz",
--	"comp_prog" => [ "gzip", "--no-name", "--rsyncable" ],
-+	"comp_prog" => [ "gzip", "--no-name" ],
- 	"decomp_prog" => [ "gunzip" ],
- 	"default_level" => 9,
+     gzip => {
+ 	file_ext => 'gz',
+-	comp_prog => [ 'gzip', '--no-name', '--rsyncable' ],
++	comp_prog => [ 'gzip', '--no-name' ],
+ 	decomp_prog => [ 'gunzip' ],
+ 	default_level => 9,
      },


### PR DESCRIPTION
This pull requests updates dpkg to the latest version available in Debian. Furthermore, this is the version of dpkg in the new release Debian 8.0 Jessie.