### PR TITLE
update .SRCINFO for every commit

### DIFF
--- a/bin/import-to-aur4.sh
+++ b/bin/import-to-aur4.sh
@@ -43,7 +43,7 @@ pushd "$TEMP"
         for p in ${PACKAGES[@]}; do
             st="$SUBDIR$p"
             git subtree split --prefix="$st" -b aur4/$p
-            git filter-branch -f --tree-filter "test -f .SRCINFO || mksrcinfo" -- aur4/$p
+            git filter-branch -f --tree-filter "mksrcinfo" -- aur4/$p
             ssh -p${AUR4PORT} ${AUR4USER}@${AUR4HOST} setup-repo "$p" || \
                 echo "Failed to setup-repo $p ... maybe it already exists?"
             git push "ssh+git://${AUR4USER}@${AUR4HOST}:${AUR4PORT}/${p}.git/" "aur4/${p}:master" || \


### PR DESCRIPTION
when the file exists, it can still be outdated
and even worse: the last `.SRCINFO` is also the first `.SRCINFO`.

Reading https://lists.archlinux.org/pipermail/aur-general/2015-June/030807.html
I realized I should have deleted more of your script :-D