### PR TITLE
Man doc moved from ./docs/man to ./man

### DIFF
--- a/aur/docker-git/.SRCINFO
+++ b/aur/docker-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = docker-git
 	pkgdesc = Pack, ship and run any application as a lightweight container
-	pkgver = 1.7.0.dev.14855.c158cdb
+	pkgver = 1.9.0.dev.16580.729c9a9
 	pkgrel = 1
 	epoch = 1
 	url = https://github.com/dotcloud/docker

--- a/aur/docker-git/PKGBUILD
+++ b/aur/docker-git/PKGBUILD
@@ -4,6 +4,7 @@
 # Contributor: Marcel Wysocki <maci@satgnu.net>
 # Contributor: Daniel YC Lin <dlin.tw@gmail>
 # Contributor: Joerg <joerg@higgsboson.tk>
+# Contributor: Vincent Aranega <vincent.aranega@gmail.com>
 #
 # NOTE: To request changes to this package, please submit a pull request
 #       to the GitHub repository at https://github.com/ido/packages-archlinux
@@ -11,7 +12,7 @@
 #
 
 pkgname=docker-git
-pkgver=1.7.0.dev.14855.c158cdb
+pkgver=1.9.0.dev.16580.729c9a9
 pkgrel=1
 epoch=1
 pkgdesc='Pack, ship and run any application as a lightweight container'
@@ -57,7 +58,7 @@ build() {
   cd docker
   export AUTO_GOPATH=1
   ./hack/make.sh dynbinary
-  for i in docs/man/*.md; do
+  for i in man/*.md; do
     go-md2man -in "$i" -out "${i%.md}"
   done
 }
@@ -80,8 +81,8 @@ package() {
   # systemd
   install -Dm644 "$srcdir/docker.service" "$pkgdir/usr/lib/systemd/system/docker.service"
   install -Dm644 "$srcdir/docker.conf" "$pkgdir/etc/sysctl.d/docker.conf"
-  
-  cd docs/man
+
+  cd man
   for section in 1 5; do
     for i in *.$section; do
       install -Dm644 "$i" "$pkgdir/usr/share/man/man$section/$i"


### PR DESCRIPTION
The man documentation seems to have moved from the 'docs/man' location to 'man' at the root of the docker repository.