### PR TITLE
Use daemon instead of -d, update doc link

### DIFF
--- a/aur/docker-git/docker.service
+++ b/aur/docker-git/docker.service
@@ -1,11 +1,11 @@
 [Unit]
 Description=Docker Application Container Engine
-Documentation=http://docs.docker.io
+Documentation=http://docs.docker.com
 After=network.target
 
 [Service]
 ExecStartPre=/usr/bin/mount --make-rprivate /
-ExecStart=/usr/bin/docker -d
+ExecStart=/usr/bin/docker daemon
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The current `docker.service` for the docker package (docker 1.8) looks like this:

```
[Unit]
Description=Docker Application Container Engine
Documentation=https://docs.docker.com
After=network.target docker.socket
Requires=docker.socket

[Service]
Type=notify
ExecStart=/usr/bin/docker daemon -H fd://
MountFlags=slave
LimitNOFILE=1048576
LimitNPROC=1048576
LimitCORE=infinity

[Install]
WantedBy=multi-user.target
```
Should we be grabbing anything extra from here too for 1.9?