### PR TITLE
Bump 0.3.6.12.2 and fix /lib-Symlink

### DIFF
--- a/aur/tn40xx/PKGBUILD
+++ b/aur/tn40xx/PKGBUILD
@@ -8,7 +8,7 @@
 
 pkgname='tn40xx'
 pkgdesc="Tehuti Networks tn40xx network driver."
-pkgver='0.3.6.12.1'
+pkgver='0.3.6.12.2'
 pkgrel=1
 arch=('x86_64')
 url='http://www.tehutinetworks.net/'
@@ -18,7 +18,7 @@ makedepends=('linux-lts-headers')
 options=('!libtool' '!strip' '!makeflags' '!buildflags' 'staticlibs')
 source=("http://www.tehutinetworks.net/images/UL240756/${pkgname}-${pkgver}.tgz"
         "tn40xx.install")
-sha512sums=('9d8391a6189f57541ace4ffee3097178a5110587dc86763647b20b8b0376f96da1fa02a3679578e5ce8fe56c56fe6e0bbb9f4fb4c6ef9d7854b11a3713f7830c'
+sha512sums=('a9e1eb3bb0b4a2f538dc79add45e764750d30f6b271865eeda2552a7623eead84dd48cb56179bbb9982922d696fec4e00f85787cdde4c47ad863dd0f3f34fe17'
             '911a59684dd0f7fa9913546a90f6144947251f2afe9fd17f6f0b9acb08c93a8dde0df70b2d1cd58de4d60eaffc7b608a978f7f2ffd4f69a22a31319818e806c0')
 install=tn40xx.install
 

--- a/aur/tn40xx/PKGBUILD
+++ b/aur/tn40xx/PKGBUILD
@@ -35,8 +35,8 @@ package() {
     install -dm755 "${pkgdir}/usr/share/doc/${pkgname}"
     install -m644 Readme release_notes \
             "${pkgdir}/usr/share/doc/${pkgname}"
-    install -dm755 "${pkgdir}/lib/modules/$(uname -r)/drivers/net/"
-    install -m755 ${pkgname}.ko "${pkgdir}/lib/modules/$(uname -r)/drivers/net/"
+    install -dm755 "${pkgdir}/usr/lib/modules/$(uname -r)/drivers/net/"
+    install -m755 ${pkgname}.ko "${pkgdir}/usr/lib/modules/$(uname -r)/drivers/net/"
     install -dm755 "${pkgdir}/etc/pm/config.d/"
     echo "SUSPEND_MODULES=${pkgname}" > "${pkgdir}/etc/pm/config.d/${pkgname}"
 }


### PR DESCRIPTION
There is still a message "error: command failed to execute correctly" after pacman installes the package, however the driver seems to work just fine