### PR TITLE
update 2.29.2

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = stanc
 	pkgdesc = A package for obtaining Bayesian inference using the No-U-Turn sampler, a variant of Hamiltonian Monte Carlo.
-	pkgver = 2.18.1
+	pkgver = 2.29.2
 	pkgrel = 1
 	url = http://mc-stan.org/
 	arch = i686
@@ -10,11 +10,7 @@ pkgbase = stanc
 	makedepends = texlive-core
 	makedepends = doxygen
 	depends = gcc-libs
-	options = !libtool
-	options = !strip
-	options = !makeflags
-	source = https://github.com/stan-dev/cmdstan/releases/download/v2.18.1/cmdstan-2.18.1.tar.gz
-	sha512sums = 20764f87e6fbc6359bc360a7316ec40773cdc4eb215f2740528830eaee765de71f8041af13235e8c64e25cb791606a739b990962469cd36ef4a87406e8d49645
+	source = https://github.com/stan-dev/cmdstan/releases/download/v2.29.2/cmdstan-2.29.2.tar.gz
+	sha512sums = 8b1485c8832fa283307b87c491f259432a7284f4975d21e5424f3b1be0ca9bf1012443c0be1b01b09aecbff40f3d1bb6031abe3bb89d8e64380f61ed9d1ffec3
 
 pkgname = stanc
-

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -11,16 +11,20 @@
 
 pkgname='stanc'
 pkgdesc="A package for obtaining Bayesian inference using the No-U-Turn sampler, a variant of Hamiltonian Monte Carlo."
-pkgver=2.18.1
+pkgver=2.29.2
 pkgrel=1
 arch=('i686' 'x86_64')
 url='http://mc-stan.org/'
 license=('BSD')
 depends=('gcc-libs')
-makedepends=('texlive-bin' 'texlive-core' 'doxygen')
-options=('!libtool' '!strip' '!makeflags')
+makedepends=('texlive-bin' 'texlive-core' 'doxygen' 
+# needed if compile against system library
+
+# 'gtest' 'benchmark' 'sundials' 'boost' 'eigen' 'tbb' 'stanmath'
+# 'python-cpplint' 'opencl-headers' 'rapidjson' 'cli11'
+)
 source=(https://github.com/stan-dev/cmdstan/releases/download/v$pkgver/cmdstan-$pkgver.tar.gz)
-sha512sums=('20764f87e6fbc6359bc360a7316ec40773cdc4eb215f2740528830eaee765de71f8041af13235e8c64e25cb791606a739b990962469cd36ef4a87406e8d49645')
+sha512sums=('8b1485c8832fa283307b87c491f259432a7284f4975d21e5424f3b1be0ca9bf1012443c0be1b01b09aecbff40f3d1bb6031abe3bb89d8e64380f61ed9d1ffec3')
 
 prepare() {
   cd "${srcdir}/cmdstan-${pkgver}"
@@ -29,12 +33,7 @@ prepare() {
 
 build() {
   cd "${srcdir}/cmdstan-${pkgver}"
- 
-  # Remove the line to avoid "fatal error: 'string' file not found"
-  # http://discourse.mc-stan.org/t/error-in-compiling-cmdstan-cstddef-string-not-found/1874
-  sed -i 's/CXXFLAGS += -stdlib=libc++//' stan/lib/stan_math/make/detect_cc
-  make bin/stanc
-  make bin/print
+  make build
   
 }
 
@@ -52,11 +51,9 @@ package() {
   # Install binaries:
   install -dm755                  "${pkgdir}/usr/bin"
   install -m755 bin/stanc         "${pkgdir}/usr/bin"
-  install -Tm755 bin/print         "${pkgdir}/usr/bin/stanc-print"
-
-  # Install static library:
-  install -dm755                  "${pkgdir}/usr/lib"
-  install -m644 bin/libstanc.a     "${pkgdir}/usr/lib"
+  install -Tm755 bin/diagnose      "${pkgdir}/usr/bin/standiagnose"
+  install -Tm755 bin/print         "${pkgdir}/usr/bin/stanprint"
+  install -Tm755 bin/stansummary   "${pkgdir}/usr/bin/stansummary"
 
   install -dm755                  "${pkgdir}/usr/include/stan"
   cd "stan/src"


### PR DESCRIPTION
Please update https://aur.archlinux.org/packages/stanc to the new version. 

Besides, I also tried to build it against system libraries, but failed. I wrote a `make/local` file like this
```makefile
MATH = /usr/include/stan/
BOOST = /usr/include/boost
EIGEN = /usr/include/eigen3
OPENCL = /usr/include/CL
TBB = /usr/include/tbb
SUNDIALS = /usr/include/sundials
BENCHMARK = /usr/include/benchmark
GTEST = /usr/include/gtest
CPPLINT = /usr/lib/python3.10/site-packages/
RAPIDJSON = /usr/include/rapidjson/
CLI11 = /usr/include/CLI/
```
But it failed to find  some file, however the files are definitely there. Could you please have a try?
```
--- Compiling the main object file. This might take up to a minute. ---
g++    -c -o src/cmdstan/main.o src/cmdstan/main.cpp
src/cmdstan/main.cpp:1:10: fatal error: cmdstan/command.hpp: No such file or directory
1 | #include <cmdstan/command.hpp>
|          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [make/program:14: src/cmdstan/main.o] Error 1
```

BTW I'd like to adopt that package or be a comaintainer. My page at aur is https://aur.archlinux.org/account/sukanka